### PR TITLE
I've made some fixes to address a server startup issue and ensure aud…

### DIFF
--- a/code/audio_in.py
+++ b/code/audio_in.py
@@ -56,7 +56,7 @@ class AudioInputProcessor:
         self.active_silence_active_callback: Optional[Callable[[bool], None]] = None
 
         self.transcriber = TranscriptionProcessor(
-            language=language,
+            source_language=language, # Corrected keyword argument
             # Callbacks for TranscriptionProcessor are internal methods of AudioInputProcessor
             realtime_transcription_callback=self._internal_on_partial,
             full_transcription_callback=self._internal_on_final,


### PR DESCRIPTION
…io signaling works correctly.

Here's a breakdown of what I changed:

1.  **Server Startup TypeError:**
    - I found a `TypeError` that was happening when the server tried to start up, specifically related to how `TranscriptionProcessor` was being set up in `code/audio_in.py`.
    - It turns out the `TranscriptionProcessor` was expecting an argument named `source_language`, but it was being given `language` instead.
    - I've corrected this in `code/audio_in.py` so it now uses `source_language=language`, which should resolve the startup error.

2.  **Client Buffering Audio Indefinitely:**
    - I noticed that after the startup error, your audio client would keep buffering audio but never send it. This suggested it wasn't getting the `user_speech_started` signal from the server.
    - Fixing the `TypeError` I mentioned above also ensures that the voice activity detection (VAD) system starts up correctly. This allows the VAD to detect speech and send the necessary `user_speech_started` signal to your client.

3.  **Language Configuration Confirmed:**
    - I also reviewed the language settings. The system is set to English ("en") by default in `code/server.py`.
    - This "en" setting is correctly used as `source_language` for the transcription process and works well with the default speech-to-text model.

With these adjustments, the server should now start up without issues, the voice activity detection should work as expected, your client should get the signal to send audio, and the speech-to-text process should function correctly with the right settings.